### PR TITLE
Add WHv emulator API declarations for SDK compatibility

### DIFF
--- a/src/hypervisor/whvp_platform.h
+++ b/src/hypervisor/whvp_platform.h
@@ -4,6 +4,30 @@
 #include <WinHvPlatform.h>
 #include <WinHvEmulation.h>
 
+// Some Windows SDK revisions ship WinHvEmulation.h without these declarations.
+extern "C" {
+HRESULT WINAPI WHvEmulatorCreateEmulator(
+    const WHV_EMULATOR_CALLBACKS* callbacks,
+    WHV_EMULATOR_HANDLE* emulator);
+
+HRESULT WINAPI WHvEmulatorDestroyEmulator(
+    WHV_EMULATOR_HANDLE emulator);
+
+HRESULT WINAPI WHvEmulatorTryIoEmulation(
+    WHV_EMULATOR_HANDLE emulator,
+    VOID* context,
+    const WHV_VP_EXIT_CONTEXT* vp_context,
+    const WHV_X64_IO_PORT_ACCESS_CONTEXT* io_instruction_context,
+    WHV_EMULATOR_STATUS* emulator_return_status);
+
+HRESULT WINAPI WHvEmulatorTryMmioEmulation(
+    WHV_EMULATOR_HANDLE emulator,
+    VOID* context,
+    const WHV_VP_EXIT_CONTEXT* vp_context,
+    const WHV_MEMORY_ACCESS_CONTEXT* mmio_instruction_context,
+    WHV_EMULATOR_STATUS* emulator_return_status);
+}
+
 namespace whvp {
 
 bool IsHypervisorPresent();


### PR DESCRIPTION
This PR adds missing WHVP emulator API declarations to improve SDK compatibility on Windows.

## Why

Some Windows SDK versions provide `WinHvEmulation.lib` exports but omit `WHvEmulator*` function declarations in `WinHvEmulation.h`.
That causes compile errors like `C3861` in `whvp_vcpu.cpp` even though link symbols exist.

## What changed

- Updated `src/hypervisor/whvp_platform.h`
- Added explicit `extern C` declarations for:
  - `WHvEmulatorCreateEmulator`
  - `WHvEmulatorDestroyEmulator`
  - `WHvEmulatorTryIoEmulation`
  - `WHvEmulatorTryMmioEmulation`

## Impact

- Fixes build failures on SDKs that omit these declarations.
- Safe on SDKs that already declare them (compatible redeclarations in C/C++).
- No runtime behavior change; this is a compile-time compatibility shim.

---
Parts of this PR were generated with Codex (with `gpt-5.3-codex`). I have conducted a full manual review and take final responsibility for the integrity of the code.