### PR TITLE
fix: bundle chromium in hermes images

### DIFF
--- a/scripts/arm64/make-rootfs-hermes.sh
+++ b/scripts/arm64/make-rootfs-hermes.sh
@@ -601,19 +601,43 @@ EOF
 
 do_install_usertools() {
     sudo chroot "$MOUNT_DIR" /bin/bash -e << EOF
-if dpkg -s jq &>/dev/null; then
+browser_ready=0
+if dpkg -s chromium &>/dev/null; then
+    if [ "$HERMES_INSTALL_BROWSER_TOOLS" != "1" ] || dpkg -s ffmpeg &>/dev/null; then
+        browser_ready=1
+    fi
+fi
+
+if dpkg -s jq &>/dev/null && [ "$browser_ready" = "1" ]; then
     echo "  User tools already installed"
     exit 0
 fi
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    jq
 
-if [ "$HERMES_INSTALL_BROWSER_TOOLS" = "1" ]; then
+if ! dpkg -s jq &>/dev/null; then
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        chromium ffmpeg
-    if ! grep -q 'PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH' /home/$USER_NAME/.bashrc 2>/dev/null; then
-        echo "export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium" >> /home/$USER_NAME/.bashrc
-    fi
+        jq
+fi
+
+if ! dpkg -s chromium &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        chromium
+fi
+
+if [ "$HERMES_INSTALL_BROWSER_TOOLS" = "1" ] && ! dpkg -s ffmpeg &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ffmpeg
+fi
+
+if ! grep -q 'PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH' /home/$USER_NAME/.bashrc 2>/dev/null; then
+    echo "export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium" >> /home/$USER_NAME/.bashrc
+fi
+
+# 关键：Hermes 首次登录和桌面帮助链接都依赖系统默认浏览器
+if [ -x /usr/bin/chromium ]; then
+    update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/chromium 200 || true
+    update-alternatives --set x-www-browser /usr/bin/chromium || true
+    update-alternatives --install /usr/bin/www-browser www-browser /usr/bin/chromium 200 || true
+    update-alternatives --set www-browser /usr/bin/chromium || true
 fi
 EOF
 }
@@ -845,17 +869,15 @@ EOF
 do_copy_readme() {
     sudo chroot "$MOUNT_DIR" /bin/bash -e << EOF
 DESKTOP_DIR="/home/$USER_NAME/Desktop"
-if [ -f "\$DESKTOP_DIR/Help.desktop" ] && [ -f "\$DESKTOP_DIR/Hermes.desktop" ]; then
-    echo "  Desktop links already copied"
-    exit 0
-fi
 
 mkdir -p "\$DESKTOP_DIR"
 chown $USER_NAME:$USER_NAME "\$DESKTOP_DIR"
 
-cp /tmp/rootfs-configs/Help.desktop "\$DESKTOP_DIR/Help.desktop"
-chown $USER_NAME:$USER_NAME "\$DESKTOP_DIR/Help.desktop"
-chmod +x "\$DESKTOP_DIR/Help.desktop"
+if [ -f /tmp/rootfs-configs/Help.desktop ]; then
+    cp /tmp/rootfs-configs/Help.desktop "\$DESKTOP_DIR/Help.desktop"
+    chown $USER_NAME:$USER_NAME "\$DESKTOP_DIR/Help.desktop"
+    chmod +x "\$DESKTOP_DIR/Help.desktop"
+fi
 
 if [ -f /tmp/rootfs-configs/Hermes.desktop ]; then
     cp /tmp/rootfs-configs/Hermes.desktop "\$DESKTOP_DIR/Hermes.desktop"
@@ -1033,9 +1055,7 @@ check "init"              test -x /sbin/init
 check "systemd"           dpkg -s systemd
 check "xfce4"             dpkg -s xfce4
 check "lightdm"           dpkg -s lightdm
-if [ "$HERMES_INSTALL_BROWSER_TOOLS" = "1" ]; then
-    check "chromium"      dpkg -s chromium
-fi
+check "chromium"          dpkg -s chromium
 check "spice-vdagent"     dpkg -s spice-vdagent
 check "qemu-guest-agent"  dpkg -s qemu-guest-agent
 check "pulseaudio"        dpkg -s pulseaudio

--- a/scripts/x86_64/make-rootfs-hermes.sh
+++ b/scripts/x86_64/make-rootfs-hermes.sh
@@ -601,19 +601,42 @@ EOF
 
 do_install_usertools() {
     sudo chroot "$MOUNT_DIR" /bin/bash -e << EOF
-if dpkg -s jq &>/dev/null; then
+browser_ready=0
+if dpkg -s chromium &>/dev/null; then
+    if [ "$HERMES_INSTALL_BROWSER_TOOLS" != "1" ] || dpkg -s ffmpeg &>/dev/null; then
+        browser_ready=1
+    fi
+fi
+
+if dpkg -s jq &>/dev/null && [ "$browser_ready" = "1" ]; then
     echo "  User tools already installed"
     exit 0
 fi
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    jq
-
-if [ "$HERMES_INSTALL_BROWSER_TOOLS" = "1" ]; then
+if ! dpkg -s jq &>/dev/null; then
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        chromium ffmpeg
-    if ! grep -q 'PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH' /home/$USER_NAME/.bashrc 2>/dev/null; then
-        echo "export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium" >> /home/$USER_NAME/.bashrc
-    fi
+        jq
+fi
+
+if ! dpkg -s chromium &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        chromium
+fi
+
+if [ "$HERMES_INSTALL_BROWSER_TOOLS" = "1" ] && ! dpkg -s ffmpeg &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ffmpeg
+fi
+
+if ! grep -q 'PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH' /home/$USER_NAME/.bashrc 2>/dev/null; then
+    echo "export PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium" >> /home/$USER_NAME/.bashrc
+fi
+
+# 关键：Hermes 首次登录和桌面帮助链接都依赖系统默认浏览器
+if [ -x /usr/bin/chromium ]; then
+    update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/chromium 200 || true
+    update-alternatives --set x-www-browser /usr/bin/chromium || true
+    update-alternatives --install /usr/bin/www-browser www-browser /usr/bin/chromium 200 || true
+    update-alternatives --set www-browser /usr/bin/chromium || true
 fi
 EOF
 }
@@ -853,9 +876,11 @@ fi
 mkdir -p "\$DESKTOP_DIR"
 chown $USER_NAME:$USER_NAME "\$DESKTOP_DIR"
 
-cp /tmp/rootfs-configs/Help.desktop "\$DESKTOP_DIR/Help.desktop"
-chown $USER_NAME:$USER_NAME "\$DESKTOP_DIR/Help.desktop"
-chmod +x "\$DESKTOP_DIR/Help.desktop"
+if [ -f /tmp/rootfs-configs/Help.desktop ]; then
+    cp /tmp/rootfs-configs/Help.desktop "\$DESKTOP_DIR/Help.desktop"
+    chown $USER_NAME:$USER_NAME "\$DESKTOP_DIR/Help.desktop"
+    chmod +x "\$DESKTOP_DIR/Help.desktop"
+fi
 
 if [ -f /tmp/rootfs-configs/Hermes.desktop ]; then
     cp /tmp/rootfs-configs/Hermes.desktop "\$DESKTOP_DIR/Hermes.desktop"
@@ -1033,9 +1058,7 @@ check "init"              test -x /sbin/init
 check "systemd"           dpkg -s systemd
 check "xfce4"             dpkg -s xfce4
 check "lightdm"           dpkg -s lightdm
-if [ "$HERMES_INSTALL_BROWSER_TOOLS" = "1" ]; then
-    check "chromium"      dpkg -s chromium
-fi
+check "chromium"          dpkg -s chromium
 check "spice-vdagent"     dpkg -s spice-vdagent
 check "qemu-guest-agent"  dpkg -s qemu-guest-agent
 check "pulseaudio"        dpkg -s pulseaudio


### PR DESCRIPTION
## 背景
Hermes 镜像默认保留了桌面 Help 链接，Hermes Agent 首次认证流程也会拉起系统浏览器，但镜像默认没有可用的默认浏览器，导致部分环境会报 `www-browser` 不存在。

## 改动
- Hermes 镜像默认安装 `chromium`
- 继续仅在 `HERMES_INSTALL_BROWSER_TOOLS=1` 时安装 `ffmpeg`
- 注册 `x-www-browser` / `www-browser` 到 `chromium`
- 保留 `Help.desktop` 和 `Hermes.desktop`
- 调整构建校验，确保 `chromium` 已安装

## 验证
- `bash -n scripts/x86_64/make-rootfs-hermes.sh`
- `bash -n scripts/arm64/make-rootfs-hermes.sh`
- 并行重打 `x86_64` / `arm64` 的 `rootfs-hermes` 镜像
- 挂载检查两套镜像，确认同时存在 `Help.desktop` / `Hermes.desktop`
- 检查 `/usr/bin/chromium`、`/usr/bin/x-www-browser`、`/usr/bin/www-browser`，确认默认浏览器已就绪


<img width="964" height="684" alt="image" src="https://github.com/user-attachments/assets/aff935c1-9dbb-484f-ae26-dfe8460c2dbd" />
