### PR TITLE
fix: preserve port forwards when renaming a VM

### DIFF
--- a/src/manager/ui/edit_vm_dialog.cpp
+++ b/src/manager/ui/edit_vm_dialog.cpp
@@ -60,6 +60,7 @@ static LRESULT CALLBACK EditDlgSubclassProc(HWND dlg, UINT msg, WPARAM wp, LPARA
             form.cpu_count          = cpu_count;
             form.debug_mode         = IsDlgButtonChecked(dlg, IDC_ED_DEBUG) == BST_CHECKED;
             form.apply_on_next_boot = running;
+            form.port_forwards      = data->rec.spec.port_forwards;
 
             auto patch = BuildVmPatch(form, data->rec.spec);
             std::string error;


### PR DESCRIPTION
## Summary
- Fix bug where host-to-guest port forwards were lost when renaming a VM
- The edit dialog form was not populating `port_forwards`, causing `BuildVmPatch` to treat the empty default as an intentional removal

## Root Cause
In `edit_vm_dialog.cpp`, the `VmEditForm` was constructed without setting `port_forwards` from the current VM spec. `BuildVmPatch` then compared the empty form field against the existing port forwards and detected a "change", writing an empty array to the patch.

## Fix
One line in `edit_vm_dialog.cpp`: populate `form.port_forwards` from `data->rec.spec.port_forwards` before building the patch.