### PR TITLE
fix: use-after-free in MacHiResTimer event handler

### DIFF
--- a/src/core/util/hires_timer_mac.cpp
+++ b/src/core/util/hires_timer_mac.cpp
@@ -65,8 +65,13 @@ public:
         dispatch_source_set_event_handler(s, ^{
             uint64_t next_ns = (*cb_holder)();
             if (next_ns == 0) {
-                // One-shot done or explicit stop: cancel ourselves.
+                // One-shot done: invalidate source_ before cancel so a
+                // concurrent ArmTimer -> Stop won't re-cancel the freed source.
                 dispatch_source_cancel(src_copy);
+                {
+                    std::lock_guard<std::mutex> lk(mu_);
+                    if (source_ == src_copy) source_ = nullptr;
+                }
                 return;
             }
             // Reschedule at the new period.


### PR DESCRIPTION
## Summary

MacHiResTimer has a use-after-free bug that causes tenbox-vm-runtime to crash with SIGSEGV when starting a VM.

## Root Cause

When the timer callback returns 0 (one-shot complete), the event handler calls dispatch_source_cancel(), which fires the cancel handler -> dispatch_release() frees the dispatch source. But source_ is not cleared, leaving a dangling pointer. A subsequent Arm() -> Stop() then passes the freed pointer to dispatch_source_cancel() -> SIGSEGV.

Crash call stack:

Vm::VCpuThreadFunc
  -> HvfVCpu::RunOnce
    -> HvfVCpu::HandleEptViolation
      -> AddressSpace::HandleMmioWrite
        -> LocalApic::ArmTimer
          -> MacHiResTimer::Stop
            -> dispatch_source_cancel -> crash

## Why the official 0.7.7 binary is unaffected

The official tenbox-vm-runtime binary (built 2026-04-21) was released before commit 6e41d57 (2026-04-22, which introduced MacHiResTimer). The official binary uses the libuv-based UvHiResTimer instead.

The main branch VERSION still reads 0.7.7, but its source code now includes MacHiResTimer - so anyone building from current main is affected.

## Fix

Clear source_ under the mutex when the event handler self-cancels (3 lines).

## Testing

- Official tenbox-vm-runtime binary -> no crash
- Build at 6e41d57~1 (before MacHiResTimer) -> no crash
- Build with this fix -> no crash