### PR TITLE
[codex] fix macOS Caps Lock forwarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ Win/macOS: tenbox-manager ──IPC v1──► tenbox-vm-runtime (WHVP / HVF)
 - **Offline-first daemon**: `tenboxd --cloud-url ""` must disable all cloud connectivity without breaking local CLI.
 - **LLM proxy** exists in two places: `src/daemon/llm_proxy.cpp` (Linux) and `src/manager/llm_proxy.cpp` (Windows); change both when the protocol changes.
 - **RemoteSession** is single-instance per VM. Read `remote_webrtc.cpp`'s `force` takeover path before adding DataChannels.
+- **macOS Caps Lock forwarding**: send Caps Lock as a tap (`down` then `up`) on each `flagsChanged` event; AppKit exposes it as a toggle state, but the guest input stack needs a full key press for every switch.
 - **Static build** (`TENBOX_STATIC_FFMPEG=ON`) requires `/opt/tenbox-deps` (only present inside the CI/packaging container). Dev builds use system shared libs — keep `ON` off by default.
 - **Release**: `docs/release.md` — VERSION bump → commit → push → tag → push tag. Always push commit before tag.
 

--- a/src/manager-macos/Input/InputHandler.swift
+++ b/src/manager-macos/Input/InputHandler.swift
@@ -82,13 +82,20 @@ class InputHandler {
 
     func handleFlagsChanged(keyCode: UInt16, modifierFlags flags: NSEvent.ModifierFlags) {
         guard let evdev = macKeyCodeToEvdev(keyCode) else { return }
+        if keyCode == Self.capsLockKeyCode {
+            activeModifierKeys.remove(keyCode)
+            pressedKeyCodes.remove(evdev)
+            onKeyEvent?(evdev, true)
+            onKeyEvent?(evdev, false)
+            return
+        }
+
         let pressed: Bool
         switch keyCode {
         case 0x38, 0x3C: pressed = flags.contains(.shift)
         case 0x3B, 0x3E: pressed = flags.contains(.control)
         case 0x3A, 0x3D: pressed = flags.contains(.option)
         case 0x37, 0x36: pressed = flags.contains(.command)
-        case 0x39:       pressed = flags.contains(.capsLock)
         default:         pressed = !activeModifierKeys.contains(keyCode)
         }
         if pressed {
@@ -120,6 +127,8 @@ class InputHandler {
     private func macKeyCodeToEvdev(_ keyCode: UInt16) -> UInt16? {
         return Self.keyMap[keyCode]
     }
+
+    private static let capsLockKeyCode: UInt16 = 0x39
 
     private static let keyMap: [UInt16: UInt16] = [
         0x12: 2,    // KEY_1


### PR DESCRIPTION
## Summary

Fixes macOS keyboard forwarding for Caps Lock so every `flagsChanged` event is sent to the guest as a complete key tap (`down` then `up`) instead of tracking AppKit's toggle state as a held key.

## Root cause

AppKit reports Caps Lock through modifier toggle state. The previous code forwarded the first toggle as `KEY_CAPSLOCK` down and the second toggle as only `KEY_CAPSLOCK` up, so the guest input method saw only one real Caps Lock press until focus loss forced a release/reset.

## Windows audit

No matching Windows fix is needed. The Windows manager maps `VK_CAPITAL` to `KEY_CAPSLOCK`, then forwards physical `WM_KEYDOWN`/`WM_SYSKEYDOWN` as pressed and `WM_KEYUP`/`WM_SYSKEYUP` as released in both the normal window path and the low-level keyboard hook path. It does not read or cache the host Caps Lock toggle state, so repeated Caps Lock presses are already delivered as full key presses to the guest.

## Impact

Users can repeatedly switch input method/case with Caps Lock in the TenBox macOS window without needing to blur and refocus the window. Windows behavior was checked and left unchanged.

## Validation

- Ad-hoc Swift harness compiled with `InputHandler.swift`: consecutive Caps Lock on/off events produced `KEY_CAPSLOCK down/up` twice, and `releaseAllPressedInputs()` emitted no extra stale release. The temporary harness file was removed after the run.
- `swift build -c debug --scratch-path /tmp/tenbox-manager-spm-caps-build` from `src/manager-macos`
- `git diff --check`
- Windows source audit: `VK_CAPITAL -> KEY_CAPSLOCK`; `WM_KEYDOWN/WM_SYSKEYDOWN -> pressed=true`; `WM_KEYUP/WM_SYSKEYUP -> pressed=false`; low-level hook uses the same pressed calculation.
- PR CI: Windows C++ build, amd64 deb, arm64 deb, and website checks all passed.
- `ctest --test-dir build/cmake-arm64 --output-on-failure` reported no registered tests.
- `cmake --build build/cmake-arm64 --target test_qcow2` passed. Manual `build/cmake-arm64/test_qcow2` execution was blocked by missing local Docker/qemu-img environment, so it is not counted as a passing validation.